### PR TITLE
for dood

### DIFF
--- a/lib/Test/PostgreSQL/Docker.pm
+++ b/lib/Test/PostgreSQL/Docker.pm
@@ -22,6 +22,7 @@ sub new {
         password=> "postgres",
         dbname  => "test",
         print_docker_error => 1,
+        docker_network => 'bridge',
         _orig_address => '',
         _pid => $$,
         %opts,


### PR DESCRIPTION
既存テストでは呼び出し元Perlはコンテナ化されていない。単純にコンテナ化するとDinDになってしまうので、DooDにする。
- github actionsのself-hostedはDinDに対応していない
- DinDはDocker自体の開発に使われている手法で他の用途に使うのはあまり推奨されていない


## dockerファイル
```
FROM perl:latest AS backend

# docker コマンドインストール
RUN apt update
RUN apt install -y docker.io docker-compose

RUN cpanm Test::PostgreSQL::Docker

CMD ["/usr/sbin/init"]
```

## docker build
`docker build -t my-perl .`

## テスト実行
- sockを共有してdood
- appコンテナからdbコンテナにアクセスするための同一ネットワークに設定
-  `-I./t/lib` は改造したTest::PostgreSQL::Dockerを読み込むためなので本来は必要ない
```

docker run -it --rm   \
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v `pwd`:`pwd` \
       -w `pwd` \
       --net=dood \
       my-perl prove -j 2 -r -I./t/lib -v t
```

## テストファイル
```perl
# t/001.t, t/002.t
use Test::More;
use Data::Dumper;
use Test::PostgreSQL::Docker;

$Test::PostgreSQL::Docker::DEBUG = 1;

my $tpd = Test::PostgreSQL::Docker->new(
    pgname => 'ghcr.io/xxxxx/xxxx-db',
    tag => 'latest',
    docker_network => 'dood',
);
ok(-x $tpd->docker,'-x $tpd->docker');
ok($tpd->docker_daemon_is_accessible, '$ptd->docker_daemon_is_accessible');
my $pg = $tpd->run(skip_pull => 1);
ok ($pg);

my $dbh = DBI->connect($pg->dsn(dbname => 'postgres'), 'postgres', '', {});
ok($dbh, $DBI::errstr);
$dbh->do('CREATE DATABASE Hoge2')  or die $dbh->errstr;

done_testing;
```

## github actionsの場合

```yaml
name: test-actions
on: [push]

jobs:
  build:
    runs-on: [self-hosted]
    steps:
      - name: Checkout
      	uses: actions/checkout@v2
      - name: run test
      	run: |
             docker network ls
             docker run --rm  -v /var/run/docker.sock:/var/run/docker.sock  -v `pwd`:`pwd`   -w `pwd`  --net=dood  my-perl prove -j 2 -r -I./t/lib -v t
```
